### PR TITLE
bugfix: import SO_REUSEPORT from core.sys.posix.sys.socket

### DIFF
--- a/source/hunt/net/NetServerImpl.d
+++ b/source/hunt/net/NetServerImpl.d
@@ -150,6 +150,8 @@ class NetServerImpl(ThreadMode threadModel = ThreadMode.Single) : AbstractLifecy
                     bool flag = this._options.isReuseAddress() || this._options.isReusePort();
                     tcpListener.setOption(SocketOptionLevel.SOCKET, cast(SocketOption) SO_EXCLUSIVEADDRUSE, !flag);
                 } else {
+                    import core.sys.posix.sys.socket : SO_REUSEPORT;
+
                     tcpListener.setOption(SocketOptionLevel.SOCKET, 
                         SocketOption.REUSEADDR, _options.isReuseAddress());
 


### PR DESCRIPTION
Personally, I would rather import it in line 140, just before its usage and inside the `else` scope of `version(Windows)`. But I'm not sure about preferred coding style of Hunt project...